### PR TITLE
Improve points co-linearity test in LineIntersector::hasIntersection.

### DIFF
--- a/src/algorithm/LineIntersector.cpp
+++ b/src/algorithm/LineIntersector.cpp
@@ -373,6 +373,21 @@ LineIntersector::hasIntersection(const Coordinate& p, const Coordinate& p1, cons
 			(CGAlgorithms::orientationIndex(p2,p1,p)==0)) {
 			return true;
 		}
+
+        // p intersects (p1,p2) if
+        // 1) lies on the segment (p1,p2) if x/y-projections intersect
+        if (p.x <= (std::max)(p1.x, p2.x) && p.x >= (std::min)(p1.x, p2.x) &&
+            p.y <= (std::max)(p1.y, p2.y) && p.y >= (std::min)(p1.y, p2.y))
+        {
+            // 2) p is collinear with p1 and p2 
+            double area = fabs(((p1.x - p.x) * (p2.y - p.y) - (p2.x - p.x) * (p1.y - p.y)) / 2);
+            double dx = p2.x - p1.x;
+            double dy = p2.y - p1.y;
+            double len = sqrt(dx * dx + dy * dy);
+            double err = 1e-6 * len; err *= err; // fraction of length to test area close-to-zero
+            if (area <= err)
+                return true;
+        }
 	}
 	return false;
 }

--- a/tests/unit/capi/GEOSPreparedGeometryTest.cpp
+++ b/tests/unit/capi/GEOSPreparedGeometryTest.cpp
@@ -170,6 +170,45 @@ namespace tut
 
     }
 
+// Test PreparedIntersects: point on segment
+    template<>
+    template<>
+    void object::test<7>()
+    {
+        // POINT located between 3rd and 4th vertex of LINESTRING
+        // POINT(-23.1094689600055 50.5195368635957)
+        std::string point("01010000009a266328061c37c0e21a172f80424940");
+        // LINESTRING(-23.122057005539 50.5201976774794,-23.1153476966995 50.5133404815199,-23.1094689600055 50.5223376452201,-23.1094689600055 50.5169177629559,-23.0961967920942 50.5330464848094,-23.0887991006034 50.5258515213185,-23.0852302622362 50.5264582238409)
+        std::string line("0102000000070000009909bf203f1f37c05c1d66d6954249404afe386d871d37c0a7eb1124b54149409c266328061c37c056d8bff5db42494098266328061c37c0034f7b5c2a42494060065c5aa01837c08ac001de3a4449408401b189bb1637c0b04e471a4f43494014ef84a6d11537c0b20dabfb62434940");
+        geom1_ = GEOSGeomFromHEX_buf(reinterpret_cast<const unsigned char*>(line.data()), line.size());
+        geom2_ = GEOSGeomFromHEX_buf(reinterpret_cast<const unsigned char*>(point.data()), point.size());
+        //geom1_ = GEOSGeomFromHEX_buf(reinterpret_cast<const unsigned char*>(point.data()), point.size());    
+        //geom2_ = GEOSGeomFromHEX_buf(reinterpret_cast<const unsigned char*>(line.data()), line.size());
+        prepGeom1_ = GEOSPrepare(geom1_);
+        ensure(0 != prepGeom1_);
+        int ret = GEOSPreparedIntersects(prepGeom1_, geom2_);
+        ensure_equals(ret, 1);
+    }
+
+    // Test PreparedIntersects: point on vertex
+    template<>
+    template<>
+    void object::test<8>()
+    {
+        // POINT located on the 3rd vertex of LINESTRING
+        // POINT(-23.1094689600055 50.5223376452201)
+        std::string point("01010000009c266328061c37c056d8bff5db424940");
+        // LINESTRING(-23.122057005539 50.5201976774794,-23.1153476966995 50.5133404815199,-23.1094689600055 50.5223376452201,-23.1094689600055 50.5169177629559,-23.0961967920942 50.5330464848094,-23.0887991006034 50.5258515213185,-23.0852302622362 50.5264582238409)
+        std::string line("0102000000070000009909bf203f1f37c05c1d66d6954249404afe386d871d37c0a7eb1124b54149409c266328061c37c056d8bff5db42494098266328061c37c0034f7b5c2a42494060065c5aa01837c08ac001de3a4449408401b189bb1637c0b04e471a4f43494014ef84a6d11537c0b20dabfb62434940");
+        geom1_ = GEOSGeomFromHEX_buf(reinterpret_cast<const unsigned char*>(line.data()), line.size());
+        geom2_ = GEOSGeomFromHEX_buf(reinterpret_cast<const unsigned char*>(point.data()), point.size());
+        prepGeom1_ = GEOSPrepare(geom1_);
+        ensure(0 != prepGeom1_);
+
+        int ret = GEOSPreparedIntersects(prepGeom1_, geom2_);
+        ensure_equals(ret, 1);
+    }
+
     // TODO: add lots of more tests
     
 } // namespace tut


### PR DESCRIPTION
Add simple test based on area of triangle created by three points of the given segment and test point.
The point intersects the segment, if area of the triangle is zero or close to zero: insignificant relatively to length of the segment.

Two interesting observations:
1. The fix allows to **pass** the **point on segment** test discussed in http://trac.osgeo.org/geos/ticket/591 and libgeos/libgeos#40
2. All GEOS tests **pass**, but one **fails**. Namely, "testA", `test<13>`): [tests/unit/algorithm/RobustLineIntersectorTest.cpp:247](https://github.com/mloskot/libgeos/blob/triangle-zero-intersects/tests/unit/algorithm/RobustLineIntersectorTest.cpp#L247) which is opposite to the "point on segment" test:

  _Segment located as close and parallel as possible to X axis, so it seems on X axis (so 0,0 intersects), but JTS/GEOS are expected to detect it's not on X axis._

I haven't tested this modification with JTS, but I might, so I could ask @dr-jts for comments too.
