### PR TITLE
Add explicit to StringTokenizer ctor and move more to the initializer list in ctor

### DIFF
--- a/include/geos/io/StringTokenizer.h
+++ b/include/geos/io/StringTokenizer.h
@@ -41,7 +41,7 @@ public:
 		TT_WORD
 	};
 	//StringTokenizer();
-	StringTokenizer(const std::string& txt);
+	explicit StringTokenizer(const std::string& txt);
 	~StringTokenizer() {}
 	int nextToken();
 	int peekNextToken();

--- a/src/io/StringTokenizer.cpp
+++ b/src/io/StringTokenizer.cpp
@@ -31,10 +31,10 @@ namespace io { // geos.io
 /*public*/
 StringTokenizer::StringTokenizer(const string &txt)
 	:
-	str(txt)
+	str(txt),
+	stok(""),
+	ntok(0.0)
 {
-	stok="";
-	ntok=0.0;
 	iter=str.begin();
 }
 


### PR DESCRIPTION
Just minor cleanup.  A little background on why I made this patch:

I am working on a fuzzer for WktReader and ran into ASAN detecting leak troubles very quickly with things like `MULTIPOLYGON  (`.  In trying to work on WktReader, I wanted to make sure I understand StringTokenizer.  In writing a test, I was passing `""` to the constructor, which created a temp object which was destroyed after the ctor resulting in a use-after-free in my test.

And might as well move everything to the constructor list that I can while I'm looking at the StringTokenizer ctor.

geos/tests/io/StringTokenizer_test.cc:

https://github.com/schwehr/gdal-autotest2/commit/dbe3d755f6137098b1f52edda40c980979685f27