### PR TITLE
Drop unavailable flags with clang during configuration

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -142,9 +142,9 @@ AX_CXX_COMPILE_STDCXX_11([noext],[mandatory])
 WARNFLAGS=""
 AC_LANG_PUSH([C++])
 dnl Available in GCC 5.1
-AX_CHECK_COMPILE_FLAG([-Wsuggest-override], [WARNFLAGS="$WARNFLAGS -Wsuggest-override"])
+AX_CHECK_COMPILE_FLAG([-Wsuggest-override -Werror], [WARNFLAGS="$WARNFLAGS -Wsuggest-override"])
 dnl Available in clang 3.5
-AX_CHECK_COMPILE_FLAG([-Wmissing-override], [WARNFLAGS="$WARNFLAGS -Wmissing-override"])
+AX_CHECK_COMPILE_FLAG([-Wmissing-override -Werror], [WARNFLAGS="$WARNFLAGS -Wmissing-override"])
 AC_LANG_POP([C++])
 
 dnl In order for AC_LIBTOOL_COMPILER_OPTION to use


### PR DESCRIPTION
By default clang (testing 6.0.0) does not return an error with unavailable flags, just a warning:
```
configure:18175: checking whether C++ compiler accepts -Wsuggest-override
configure:18194: clang++ -c -g -O2  -Wsuggest-override -D_FORTIFY_SOURCE=2 conftest.cpp >&5
warning: unknown warning option '-Wsuggest-override'; did you mean '-Wshift-overflow'? [-Wunknown-warning-option]
1 warning generated.
configure:18194: $? = 0
configure:18202: result: yes
configure:18210: checking whether C++ compiler accepts -Wmissing-override
configure:18229: clang++ -c -g -O2  -Wmissing-override -D_FORTIFY_SOURCE=2 conftest.cpp >&5
warning: unknown warning option '-Wmissing-override'; did you mean '-Wmissing-noescape'? [-Wunknown-warning-option]
1 warning generated.
configure:18229: $? = 0
```

Which causes the build to spit warnings constantly:
```
libtool: compile:  clang++ -DHAVE_CONFIG_H -I. -I../../../include -I../../../include/geos -I../../../include -D_FORTIFY_SOURCE=2 -DGEOS_INLINE -Wsuggest-override -Wmissing-override -pedantic -Wall -Wno-long-long -DUSE_UNSTABLE_GEOS_CPP_API -g -O2 -MT Node.lo -MD -MP -MF .deps/Node.Tpo -c Node.cpp  -fPIC -DPIC -o .libs/Node.o
warning: unknown warning option '-Wsuggest-override'; did you mean '-Wshift-overflow'? [-Wunknown-warning-option]
warning: unknown warning option '-Wmissing-override'; did you mean '-Wmissing-noescape'? [-Wunknown-warning-option]
```